### PR TITLE
Rename slug to just `poker`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ dist
 # obsidian
 data.json
 vault/.obsidian/workspace.json
-vault/.obsidian/plugins/obsidian-poker/*
-!vault/.obsidian/plugins/obsidian-poker/.hotreload
+vault/.obsidian/plugins/poker/*
+!vault/.obsidian/plugins/poker/.hotreload
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Plugin to render poker cards in Obsidian.
 
 ## How to Install
 
-In Obsidian go to `Settings > Third-party plugins > Community Plugins > Browse` and search for `Obsidian Poker`.
+In Obsidian go to `Settings > Third-party plugins > Community Plugins > Browse` and search for `Poker`.
 
 ### Manual installation
 
@@ -16,7 +16,7 @@ Unzip the [latest release](https://github.com/mAAdhaTTah/obsidian-poker/releases
 
 ## How to Configure
 
-The plugin allows you to customize the prefix you use for inline cards. Go to `Settings -> Obsidian Poker` to customize. The plugin defaults to `pkr` as the prefix.
+The plugin allows you to customize the prefix you use for inline cards. Go to `Settings -> Poker` to customize. The plugin defaults to `pkr` as the prefix.
 
 ## How to Use
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -48,15 +48,13 @@ const context = await esbuild.context({
         to: [
           prod
             ? "./dist/manifest.json"
-            : "./vault/.obsidian/plugins/obsidian-poker/manifest.json",
+            : "./vault/.obsidian/plugins/poker/manifest.json",
         ],
       },
       watch: true,
     }),
   ],
-  outfile: prod
-    ? "dist/main.js"
-    : "vault/.obsidian/plugins/obsidian-poker/main.js",
+  outfile: prod ? "dist/main.js" : "vault/.obsidian/plugins/poker/main.js",
 });
 
 if (prod) {

--- a/main.ts
+++ b/main.ts
@@ -208,7 +208,7 @@ class PokerSettingTab extends PluginSettingTab {
 
     containerEl.empty();
 
-    containerEl.createEl("h2", { text: "Settings for Obsidian Poker." });
+    containerEl.createEl("h2", { text: "Settings for Poker." });
 
     new Setting(containerEl)
       .setName("Prefix")

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "id": "obsidian-poker",
-  "name": "Obsidian Poker",
+  "id": "poker",
+  "name": "Poker",
   "version": "1.0.0",
   "minAppVersion": "0.15.0",
   "description": "Renders poker hands in Obsidian.",

--- a/vault/.obsidian/community-plugins.json
+++ b/vault/.obsidian/community-plugins.json
@@ -1,4 +1,4 @@
 [
-  "obsidian-poker",
+  "poker",
   "hot-reload"
 ]


### PR DESCRIPTION
They don't want "obsidian" in the name or slug.