### PR TITLE
Fix inline code embedded in list, heading, etc

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -241,7 +241,7 @@ class BaseCardIconsViewPlugin implements PluginValue {
         from,
         to,
         enter: node => {
-          if (node.type.name === "inline-code") {
+          if (node.type.name.includes("inline-code")) {
             const text = view.state.doc.sliceString(node.from, node.to);
             const match = this.plugin.boardRegex.exec(text);
 

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
 .pkr-inline-cards {
   display: inline-flex;
-  vertical-align: top;
+  vertical-align: middle;
 }

--- a/vault/hand.md
+++ b/vault/hand.md
@@ -1,1 +1,7 @@
 This is a flop: `pkr:8c9h2s`. Let's see how this looks with a bunch of text on multiple lines. Here's a hand: `pkr:KhKc`. Does this look alright? We could shove `pkr:Kh`x without issue.
+
+- Card in a bullet `pkr:Kh`
+
+# Card in a heading `pkr:Kh`
+
+Ace and any side card, of any suit: `pkr:AxXs`


### PR DESCRIPTION
Type is weirdly long when embedded so use `includes`.